### PR TITLE
Add SessionService and enable domain aliases

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,4 @@
 APP_ENV='local'
-APP_TOP_LEVEL_DOMAIN='example.com'
-APP_DOMAIN='auth.example.com'
 
 MAILGUN_API_KEY='your_mailgun_api_key'
 MAILGUN_DOMAIN='your_mailgun_domain'

--- a/README.md
+++ b/README.md
@@ -36,26 +36,26 @@ http {
         listen 80;
 
         location / {
-                auth_request /auth; # Define the internal location for auth checks
-                error_page 401 = @error401; # Define what happens on 401 error
-                
-                # Whatever config you have here for the resource.
-            }
+            auth_request /auth; # Define the internal location for auth checks
+            error_page 401 = @error401; # Define what happens on 401 error
             
-            # Define the service to call for auth validation
-            location = /auth {
-                internal;
-                proxy_pass https://auth-wrap.example.co.uk/validate;
-                proxy_ssl_server_name on; # This was needed to get SSL checks to pass. Not entirely sure why.
-                proxy_pass_request_body off;
-                proxy_set_header Cookie $http_cookie;  # Forward the cookies received from the client. This ensures the session ID from the auth service is used when validating.
-                proxy_set_header Content-Length "";
-                proxy_set_header X-Original-URL $host$request_uri; # Pass the intended destination, used by the auth service for validation and redirection.
-            }
-        
-            location @error401 {
-                return 302 https://auth-wrap.example.co.uk/login?redirect=$host$request_uri;
-            }
+            # Whatever config you have here for the resource.
+        }
+            
+        # Define the service to call for auth validation
+        location = /auth {
+            internal;
+            proxy_pass https://auth-wrap.example.co.uk/validate;
+            proxy_ssl_server_name on; # This was needed to get SSL checks to pass. Not entirely sure why.
+            proxy_pass_request_body off;
+            proxy_set_header Cookie $http_cookie;  # Forward the cookies received from the client. This ensures the session ID from the auth service is used when validating.
+            proxy_set_header Content-Length "";
+            proxy_set_header X-Original-URL $host$request_uri; # Pass the intended destination, used by the auth service for validation and redirection.
+        }
+    
+        location @error401 {
+            return 302 https://auth-wrap.example.co.uk/login?redirect=$host$request_uri;
+        }
     }
 }
 ```

--- a/src/App.php
+++ b/src/App.php
@@ -24,20 +24,16 @@ class App {
         ini_set('session.gc_maxlifetime', $sessionDuration);
         
         # Ensure cookies are set on the top level domain, so that the auth service works for all sub-domain sites. They access the same cookies.
-        // Function to get the top level domain from a given host
-        function getTopLevelDomain($host) {
+        // Function to get the main domain by removing the subdomain
+        function getMainDomain($host) {
             $parts = explode('.', $host);
-            $numParts = count($parts);
-        
-            if ($numParts > 2) {
-                // Return the last two parts of the domain
-                return $parts[$numParts - 2] . '.' . $parts[$numParts - 1];
-            }
-            return $host;
+            // Remove the first part (subdomain) and join the remaining parts
+            array_shift($parts);
+            return implode('.', $parts);
         }
         
         // Determine the domain based on the current request
-        $domain = ($_ENV['APP_ENV'] === 'local') ? 'localhost' : getTopLevelDomain($_SERVER['HTTP_HOST']);
+        $domain = ($_ENV['APP_ENV'] === 'local') ? 'localhost' : getMainDomain($_SERVER['HTTP_HOST']);
         
         // Prefix with a dot to include all subdomains
         if ($domain !== 'localhost') {

--- a/src/App.php
+++ b/src/App.php
@@ -44,6 +44,7 @@ class App {
             $domain = '.' . $domain;
         }
 
+        Log::info('HTTP_HOST: ' . $_SERVER['HTTP_HOST'] ?? 'No HTTP_HOST specified');
         Log::info('Setting session cookie params: domain = ' . $domain . ', lifetime = ' . $sessionDuration . ', secure = true, httponly = true, samesite = Lax');
 
         session_set_cookie_params([

--- a/src/App.php
+++ b/src/App.php
@@ -24,10 +24,26 @@ class App {
         ini_set('session.gc_maxlifetime', $sessionDuration);
         
         # Ensure cookies are set on the top level domain, so that the auth service works for all sub-domain sites. They access the same cookies.
-        $domain = '.' . $_ENV['APP_TOP_LEVEL_DOMAIN'];
-        if($_ENV['APP_ENV'] === 'local') {
-            $domain = 'localhost';
+        // Function to get the top level domain from a given host
+        function getTopLevelDomain($host) {
+            $parts = explode('.', $host);
+            $numParts = count($parts);
+        
+            if ($numParts > 2) {
+                // Return the last two parts of the domain
+                return $parts[$numParts - 2] . '.' . $parts[$numParts - 1];
+            }
+            return $host;
         }
+        
+        // Determine the domain based on the current request
+        $domain = ($_ENV['APP_ENV'] === 'local') ? 'localhost' : getTopLevelDomain($_SERVER['HTTP_HOST']);
+        
+        // Prefix with a dot to include all subdomains
+        if ($domain !== 'localhost') {
+            $domain = '.' . $domain;
+        }
+        
         session_set_cookie_params([
             'domain' => $domain,
             'lifetime' => $sessionDuration,

--- a/src/App.php
+++ b/src/App.php
@@ -88,16 +88,18 @@ class App {
         Log::info('Email in session: ' . $_SESSION['email'] ?? 'No email in session');
         Log::info('Authenticated: ' . $_SESSION['authenticated'] ?? 'Not authenticated');
 
-        if($this->sessionService->isAuthenticated()) {
+        if(!$this->sessionService->isAuthenticated()) {
             Log::info('User not authenticated. Sending 401 Unauthorized.');
             $this->headerService->send('HTTP/1.1 401 Unauthorized');
             return;
         }
+        
         if(!isset($_SERVER['HTTP_X_ORIGINAL_URL'])) {
             Log::info('No original URI. Sending 401 Unauthorized.');
             $this->headerService->send('HTTP/1.1 401 Unauthorized');
             return;
         }
+
         $email = $this->sessionService->get('email');
         if(!isset($email)) {
             Log::info('No email in session. Sending 401 Unauthorized.');

--- a/src/App.php
+++ b/src/App.php
@@ -43,7 +43,9 @@ class App {
         if ($domain !== 'localhost') {
             $domain = '.' . $domain;
         }
-        
+
+        Log::info('Setting session cookie params: domain = ' . $domain . ', lifetime = ' . $sessionDuration . ', secure = true, httponly = true, samesite = Lax');
+
         session_set_cookie_params([
             'domain' => $domain,
             'lifetime' => $sessionDuration,

--- a/src/Container.php
+++ b/src/Container.php
@@ -23,6 +23,9 @@ class Container {
     # This does not necessarily set up all dependencies, but it sets up the ones that are not environment-specific
     public static function setUpDependencies(Container $container) {
         // Setup dependency injection container
+        $container->bind('SessionService', function() {
+            return new \App\Core\SessionService();
+        });
         $container->bind('Mailgun', function() {
             return Mailgun::create($_ENV['MAILGUN_API_KEY'], $_ENV['MAILGUN_API_BASE_URL'] ?? null);
         });

--- a/src/Core/AuthChecker.php
+++ b/src/Core/AuthChecker.php
@@ -46,12 +46,12 @@ class AuthChecker {
         $expires = time() + 3600; // 1 hour expiration
         $this->storeTokenData($email, $redirect, $token, $expires);
         
-        if (strpos($_ENV['APP_DOMAIN'], 'localhost') !== false) {
+        if (strpos($_SERVER['HTTP_HOST'], 'localhost') !== false) {
             $scheme = 'http://';
         } else {
             $scheme = 'https://';
         }
-        return $scheme . $_ENV['APP_DOMAIN'] . '/confirm-email?auth_token=' . $token;
+        return $scheme . $_SERVER['HTTP_HOST'] . '/confirm-email?auth_token=' . $token;
     }
 
     # Generate a unique token

--- a/src/Core/SessionService.php
+++ b/src/Core/SessionService.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Core;
+
+class SessionService {
+
+    public function startSession() {
+        $sessionDuration = 3600 * 32; // 1 Day + 8 hours so it doesn't expire during the working day no matter when it was set
+        ini_set('session.gc_maxlifetime', $sessionDuration);
+        
+        # Ensure cookies are set on the top level domain, so that the auth service works for all sub-domain sites. They access the same cookies.
+        $hostParts = explode('.', $_SERVER['HTTP_HOST']);
+        # Remove the first part (subdomain) and join the remaining parts
+        array_shift($hostParts); 
+        $topLevelDomain = implode('.', $hostParts);
+        
+        $topLevelDomain = ($_ENV['APP_ENV'] === 'local') ? 'localhost' : $topLevelDomain;
+        
+        # Prefix with a dot to include all subdomains, unless localhost
+        if ($topLevelDomain !== 'localhost') {
+            $topLevelDomain = '.' . $topLevelDomain;
+        }
+
+        Log::info('HTTP_HOST: ' . $_SERVER['HTTP_HOST'] ?? 'No HTTP_HOST specified');
+        Log::info('Setting session cookie params: domain = ' . $topLevelDomain . ', lifetime = ' . $sessionDuration . ', secure = true, httponly = true, samesite = Lax');
+
+        session_set_cookie_params([
+            'domain' => $topLevelDomain,
+            'lifetime' => $sessionDuration,
+            'secure' => true, 
+            'httponly' => true, 
+            'samesite' => 'Lax'
+        ]);
+        session_name('auth-wrap-session');
+        session_start();
+    }
+
+    public function isAuthenticated() {
+        return isset($_SESSION['authenticated']);
+    }
+
+    public function setAuthenticated($email) {
+        $_SESSION['authenticated'] = true;
+        $_SESSION['email'] = $email;
+    }
+
+    public function removeAuthenticated() {
+        if(isset($_SESSION['authenticated'])) {
+            unset($_SESSION['authenticated']);
+        }
+    }
+
+    public function setCsrfToken() {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+
+    public function validateCsrfToken($token) {
+        Log::info('Validating CSRF token: ' . $token ?? 'No token specified');
+        Log::info('Session CSRF token: ' . $_SESSION['csrf_token'] ?? 'No session token specified');
+        if (!isset($token) || $token != $_SESSION['csrf_token']) {
+            Log::info('CSRF token invalid.');
+            return false;
+        }
+        Log::info('CSRF token valid.');
+        unset($_SESSION['csrf_token']); // Unset the CSRF token to prevent re-use
+        return true;
+    }
+
+    public function set($key, $value) {
+        $_SESSION[$key] = $value;
+    }
+
+    public function get($key) {
+        return $_SESSION[$key] ?? null;
+    }
+
+    public function remove($key) {
+        unset($_SESSION[$key]);
+    }
+
+}

--- a/src/Core/SessionService.php
+++ b/src/Core/SessionService.php
@@ -55,8 +55,7 @@ class SessionService {
     }
 
     public function validateCsrfToken($token) {
-        Log::info('Validating CSRF token: ' . $token ?? 'No token specified');
-        Log::info('Session CSRF token: ' . $_SESSION['csrf_token'] ?? 'No session token specified');
+        Log::info('Validating CSRF token');
         if (!isset($token) || $token != $_SESSION['csrf_token']) {
             Log::info('CSRF token invalid.');
             return false;


### PR DESCRIPTION
SessionService added for managing the session including the session auth and CSRF token validation.
Also updated session settings to allow for multiple domain aliases on the host of auth-wrap. This allows us to use a single instance of auth-wrap to validate staging sites hosted on different domains. 
Auth-wrap just needs to be hosted with domain aliases for each domain that it is used for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed unused environment variables from the example configuration.

- **Documentation**
	- Updated server setup instructions to improve authentication handling and error responses.

- **New Features**
	- Added a new `SessionService` for streamlined session management.
	- Updated email link generation to dynamically adapt to different environments.

- **Refactor**
	- Refactored session handling across the application to use the new `SessionService`.
	- Improved code readability and maintainability in session management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->